### PR TITLE
tidy error message

### DIFF
--- a/anki/runner.go
+++ b/anki/runner.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -290,6 +291,9 @@ func (r *Runner) postCSVRequest(ctx context.Context, endpoint, deck string, body
 
 	resp, err := r.client.Do(req)
 	if err != nil {
+		if err, ok := errors.AsType[*net.OpError](err); ok && err.Op == "dial" {
+			return fmt.Errorf("failed to connect to Anki. Are Anki and Laverna Anki Addon running?")
+		}
 		return fmt.Errorf("%T.Do(): %w", r.client, err)
 	}
 	defer func() {


### PR DESCRIPTION
closes https://github.com/mrwormhole/laverna/issues/36



Added the feature below to report the nicer error message rather than generic dial up TCP connection error.

```
❯ ./main anki -p Talha -d my-deck-3 -v th -f ./testdata/anki-th-example.csv
2026/04/06 15:37:59 failed to run: *anki.Runner.postCSVRequest(http://localhost:5555/v1/import-csv, my-deck-3): failed to connect to Anki. Are Anki and Laverna Anki Addon running?
```